### PR TITLE
Github Actions workflow for building the toolchain and the SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, macos-10.15]
+        os: [ubuntu-16.04, ubuntu-18.04]
     
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Install dependencies
         run: sudo apt install -y libboost-program-options-dev libmpfr-dev libmpc-dev
       - name: Build
-        run: make
+        run: make -j4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,24 +32,13 @@ jobs:
       - uses: actions/cache@v2
         id: toolchain-cache
         with:
-          path: |
-            toolchain.tar.gz
-            ndless-sdk/toolchain/install
+          path: ndless-sdk/toolchain/install
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
           key: ${{ matrix.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
       - name: Build toolchain
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
-      - name: Package toolchain
-        if: steps.toolchain-cache.outputs.cache-hit != 'true'
-        run: tar -cvzf toolchain.tar.gz ndless-sdk/toolchain/install
-      
-      - name: Upload built toolchain
-        uses: actions/upload-artifact@v2
-        with:
-          name: toolchain-${{ matrix.os }}
-          path: toolchain.tar.gz
       
       # actual build starts here
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build-toolchain:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -18,19 +18,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        # we don't need submodules for building the toolchain
+        # we don't need submodules for building the toolchain, but we do for everything else
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0 # submodule checkout does not work with depth=1 (the default)
 
-      # toolchain takes ~40min to build, so we want to avoid that whenever possible!
+      # build the toolchain first
+      # it takes ~40min to build, so we want to avoid that whenever possible!
       - uses: actions/cache@v2
         id: toolchain-cache
         with:
-          path: toolchain.tar.gz
+          path: |
+            toolchain.tar.gz
+            ndless-sdk/toolchain/install
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
           key: ${{ matrix.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
       - name: Install dependencies
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         run: sudo apt install -y libmpfr-dev libmpc-dev
-      - name: Build
+      - name: Build toolchain
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
@@ -43,32 +49,13 @@ jobs:
         with:
           name: toolchain-${{ matrix.os }}
           path: toolchain.tar.gz
-  build-sdk:
-    needs: build-toolchain
-    
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-    
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-          fetch-depth: 0 # submodule checkout does not work with depth=1 (the default)
       
-      - name: Download built toolchain
-        uses: actions/download-artifact@v2
-        with:
-          name: toolchain-${{ matrix.os }}
-      - name: Extract toolchain
-        run: tar -xvzf toolchain.tar.gz ndless-sdk/toolchain/install
+      # actual build starts here
       - name: Set up PATH
         run: |
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/bin"
       - name: Install dependencies
-        run: sudo apt install -y libboost-program-options-dev libmpfr-dev libmpc-dev
+        run: sudo apt install -y libboost-program-options-dev
       - name: Build
         run: make -j4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: toolchain
-          path: toolchain.tar
+          path: toolchain.tar.gz
   build-sdk:
     needs: build-toolchain
     runs-on: ubuntu-latest
@@ -56,7 +56,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: toolchain
-          path: toolchain.tar
+          path: toolchain.tar.gz
       - name: Extract toolchain
         run: tar -xvzf toolchain.tar.gz ndless-sdk/toolchain/install
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,6 @@ jobs:
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/bin"
       - name: Install dependencies
-        run: sudo apt install -y libboost-program-options-dev
+        run: sudo apt install -y libboost-program-options-dev libmpfr-dev libmpc-dev
       - name: Build
         run: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: toolchain.tar.gz
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
-          key: ${{ runner.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
+          key: ${{ matrix.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
       - name: Install dependencies
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         run: sudo apt install -y libmpfr-dev libmpc-dev
@@ -41,7 +41,7 @@ jobs:
       - name: Upload built toolchain
         uses: actions/upload-artifact@v2
         with:
-          name: toolchain-${{ runner.os }}
+          name: toolchain-${{ matrix.os }}
           path: toolchain.tar.gz
   build-sdk:
     needs: build-toolchain
@@ -61,7 +61,7 @@ jobs:
       - name: Download built toolchain
         uses: actions/download-artifact@v2
         with:
-          name: toolchain-${{ runner.os }}
+          name: toolchain-${{ matrix.os }}
       - name: Extract toolchain
         run: tar -xvzf toolchain.tar.gz ndless-sdk/toolchain/install
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
         id: toolchain-cache
         with:
           path: |
-            toolchain.tar.gz
             ndless-sdk/toolchain/install
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
           key: ${{ matrix.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
@@ -41,15 +40,12 @@ jobs:
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
-      - name: Package toolchain
-        if: steps.toolchain-cache.outputs.cache-hit != 'true'
-        run: tar -cvzf toolchain.tar.gz ndless-sdk/toolchain/install
       
       - name: Upload built toolchain
         uses: actions/upload-artifact@v2
         with:
           name: toolchain-${{ matrix.os }}
-          path: toolchain.tar.gz
+          path: ndless-sdk/toolchain/install
       
       # actual build starts here
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0 # submodule checkout does not work with depth=1 (the default)
 
+      # needed both at compile- and runtime for the toolchain
+      - name: Install dependencies
+        run: sudo apt install -y libgmp-dev libmpfr-dev libmpc-dev
+
       # build the toolchain first
       # it takes ~40min to build, so we want to avoid that whenever possible!
       - uses: actions/cache@v2
@@ -33,9 +37,6 @@ jobs:
             ndless-sdk/toolchain/install
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
           key: ${{ matrix.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
-      - name: Install dependencies
-        if: steps.toolchain-cache.outputs.cache-hit != 'true'
-        run: sudo apt install -y libmpfr-dev libmpc-dev
       - name: Build toolchain
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         working-directory: ndless-sdk/toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: toolchain
-          path: toolchain.tar.gz
       - name: Extract toolchain
         run: tar -xvzf toolchain.tar.gz ndless-sdk/toolchain/install
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install toolchain dependencies
         run: sudo apt install -y libgmp-dev libmpfr-dev libmpc-dev
 
+      # ndless-sdk
       # build the toolchain first
       # it takes ~40min to build, so we want to avoid that whenever possible!
       - uses: actions/cache@v2
@@ -40,11 +41,11 @@ jobs:
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
       
-      # actual build starts here
+      # ndless
       - name: Set up PATH
         run: |
-          echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"
-          echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/bin"
+          echo "$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/ndless-sdk/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: sudo apt install -y libboost-program-options-dev
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,15 @@ jobs:
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
+      - name: Package toolchain
+        if: steps.toolchain-cache.outputs.cache-hit != 'true'
+        run: tar -cvf toolchain.tar ndless-sdk/toolchain/install
       
       - name: Upload built toolchain
         uses: actions/upload-artifact@v2
         with:
           name: toolchain
-          path: ndless-sdk/toolchain/install
+          path: toolchain.tar
   build-sdk:
     needs: build-toolchain
     runs-on: ubuntu-latest
@@ -53,10 +56,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: toolchain
-          path: ndless-sdk/toolchain/install
-      # necessary because +x isn't retained in the artifact
-      - name: Fix toolchain permissions
-        run: chmod +x ndless-sdk/toolchain/install/bin/*
+          path: toolchain.tar
+      - name: Extract toolchain
+        run: tar -xvf toolchain.tar ndless-sdk/toolchain/install
       - name: Set up PATH
         run: |
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0 # submodule checkout does not work with depth=1 (the default)
 
       # needed both at compile- and runtime for the toolchain
-      - name: Install dependencies
+      - name: Install toolchain dependencies
         run: sudo apt install -y libgmp-dev libmpfr-dev libmpc-dev
 
       # build the toolchain first

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,11 @@ jobs:
           path: toolchain.tar.gz
   build-sdk:
     needs: build-toolchain
-    runs-on: ubuntu-latest
+    
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, macos-10.15]
     
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -45,6 +43,7 @@ jobs:
   build-sdk:
     needs: build-toolchain
     runs-on: ubuntu-latest
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
 
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
     
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   build-toolchain:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04]
 
     steps:
       - name: Checkout
@@ -38,7 +41,7 @@ jobs:
       - name: Upload built toolchain
         uses: actions/upload-artifact@v2
         with:
-          name: toolchain
+          name: toolchain-${{ runner.os }}
           path: toolchain.tar.gz
   build-sdk:
     needs: build-toolchain
@@ -58,7 +61,7 @@ jobs:
       - name: Download built toolchain
         uses: actions/download-artifact@v2
         with:
-          name: toolchain
+          name: toolchain-${{ runner.os }}
       - name: Extract toolchain
         run: tar -xvzf toolchain.tar.gz ndless-sdk/toolchain/install
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           name: toolchain
           path: ndless-sdk/toolchain/install
+      # necessary because +x isn't retained in the artifact
+      - name: Fix toolchain permissions
+        run: chmod +x ndless-sdk/toolchain/install/bin/*
       - name: Set up PATH
         run: |
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-toolchain:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        # we don't need submodules for building the toolchain
+
+      # toolchain takes ~40min to build, so we want to avoid that whenever possible!
+      - uses: actions/cache@v2
+        id: toolchain-cache
+        with:
+          path: ndless-sdk/toolchain/install
+          # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
+          key: ${{ runner.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
+      - name: Install dependencies
+        if: steps.toolchain-cache.outputs.cache-hit != 'true'
+        run: sudo apt install -y libmpfr-dev libmpc-dev
+      - name: Build
+        if: steps.toolchain-cache.outputs.cache-hit != 'true'
+        working-directory: ndless-sdk/toolchain
+        run: ./build_toolchain.sh
+      
+      - name: Upload built toolchain
+        uses: actions/upload-artifact@v2
+        with:
+          name: toolchain
+          path: ndless-sdk/toolchain/install
+  build-sdk:
+    needs: build-toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0 # submodule checkout does not work with depth=1 (the default)
+      
+      - name: Download built toolchain
+        uses: actions/download-artifact@v2
+        with:
+          name: toolchain
+          path: ndless-sdk/toolchain/install
+      - name: Set up PATH
+        run: |
+          echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"
+          echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/bin"
+      - name: Install dependencies
+        run: sudo apt install -y libboost-program-options-dev
+      - name: Build
+        run: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
         id: toolchain-cache
         with:
           path: |
+            toolchain.tar.gz
             ndless-sdk/toolchain/install
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
           key: ${{ matrix.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
@@ -40,12 +41,15 @@ jobs:
         if: steps.toolchain-cache.outputs.cache-hit != 'true'
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
+      - name: Package toolchain
+        if: steps.toolchain-cache.outputs.cache-hit != 'true'
+        run: tar -cvzf toolchain.tar.gz ndless-sdk/toolchain/install
       
       - name: Upload built toolchain
         uses: actions/upload-artifact@v2
         with:
           name: toolchain-${{ matrix.os }}
-          path: ndless-sdk/toolchain/install
+          path: toolchain.tar.gz
       
       # actual build starts here
       - name: Set up PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/cache@v2
         id: toolchain-cache
         with:
-          path: ndless-sdk/toolchain/install
+          path: toolchain.tar.gz
           # gcc/binutils/etc versions are in build_toolchain.sh, so that'll be part of our cache key
           key: ${{ runner.os }}-${{ hashFiles('ndless-sdk/toolchain/build_toolchain.sh') }}
       - name: Install dependencies
@@ -34,8 +34,7 @@ jobs:
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
       - name: Package toolchain
-        if: steps.toolchain-cache.outputs.cache-hit != 'true'
-        run: tar -cvf toolchain.tar ndless-sdk/toolchain/install
+        run: tar -cvzf toolchain.tar.gz ndless-sdk/toolchain/install
       
       - name: Upload built toolchain
         uses: actions/upload-artifact@v2
@@ -58,7 +57,7 @@ jobs:
           name: toolchain
           path: toolchain.tar
       - name: Extract toolchain
-        run: tar -xvf toolchain.tar ndless-sdk/toolchain/install
+        run: tar -xvzf toolchain.tar.gz ndless-sdk/toolchain/install
       - name: Set up PATH
         run: |
           echo "::add-path::$GITHUB_WORKSPACE/ndless-sdk/toolchain/install/bin"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
         working-directory: ndless-sdk/toolchain
         run: ./build_toolchain.sh
       - name: Package toolchain
+        if: steps.toolchain-cache.outputs.cache-hit != 'true'
         run: tar -cvzf toolchain.tar.gz ndless-sdk/toolchain/install
       
       - name: Upload built toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
My original motivation for this was to let you provide "nightly" builds of the SDK and toolchain, so our CI would not have to duplicate effort, but it seems that GitHub Actions does not let you easily download artifacts from other repositories (yet?).

Still, the effort was made, so here's a free CI workflow for your project! :)

On runtimes:

- The toolchain takes roughly 40 minutes to build. Caching is implemented, and a rebuild is triggered whenever the `build-toolchain.sh` script changes (because it contains the gcc, binutils, etc version numbers used to build the toolchain).
- The ndless SDK builds fairly quick, so there is no caching for that job.